### PR TITLE
MD and MDX use the same Page Templates

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -76,13 +76,6 @@ module.exports = {
     },
     {
       resolve: `gatsby-plugin-mdx`,
-      // options: {
-      //   defaultLayouts: {
-      //     default: require.resolve(
-      //       `${__dirname}/src/components/templates/mdx-guide-template.js`
-      //     ),
-      //   },
-      // },
     },
     {
       resolve: `gatsby-source-filesystem`,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -75,6 +75,16 @@ module.exports = {
       },
     },
     {
+      resolve: `gatsby-plugin-mdx`,
+      // options: {
+      //   defaultLayouts: {
+      //     default: require.resolve(
+      //       `${__dirname}/src/components/templates/mdx-guide-template.js`
+      //     ),
+      //   },
+      // },
+    },
+    {
       resolve: `gatsby-source-filesystem`,
       options: {
         name: `pages`,
@@ -94,16 +104,7 @@ module.exports = {
         path: `${__dirname}/src/guides`,
       },
     },
-    {
-      resolve: `gatsby-plugin-mdx`,
-      options: {
-        defaultLayouts: {
-          default: require.resolve(
-            `${__dirname}/src/components/templates/mdx-guide-template.js`
-          ),
-        },
-      },
-    },
+
     {
       resolve: `gatsby-transformer-remark`,
       options: {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -74,6 +74,18 @@ exports.createPages = ({ actions, graphql }) => {
       return Promise.reject(result.errors)
     }
 
+    result.data.allMdx.edges.forEach(({ node }) => {
+      createPage({
+        path: node.fields.slug,
+        component: path.resolve(
+          "src/components/templates/mdx-guide-template.js"
+        ),
+        context: {
+          slug: node.fields.slug,
+        },
+      })
+    })
+
     result.data.allMarkdownRemark.edges.forEach(({ node }) => {
       if (node.frontmatter && node.frontmatter.type === "individual-course") {
         createPage({

--- a/src/components/templates/guide-template.js
+++ b/src/components/templates/guide-template.js
@@ -35,8 +35,6 @@ export default function Template({
   )
 }
 
-// TODO I do not like how we have 'is index page'
-
 export const pageQuery = graphql`
   query($slug: String!) {
     markdownRemark(fields: { slug: { eq: $slug } }) {

--- a/src/components/templates/mdx-guide-template.js
+++ b/src/components/templates/mdx-guide-template.js
@@ -1,7 +1,10 @@
 import React from "react"
 import BlogPostLayout from "./blog-post-layout"
 import CourseGraph from "../courses/course-graph"
+import { graphql } from "gatsby"
 import { MDXProvider } from "@mdx-js/react"
+import { MDXRenderer } from "gatsby-plugin-mdx"
+import TableOfContents from "../table-of-contents"
 
 /* 
 Read more about MDX (Markdown X) here 
@@ -18,20 +21,47 @@ https://github.com/gatsbyjs/gatsby/issues/16224
 
 const shortcodes = { CourseGraph }
 
-export default function Template({
-  path,
-  children,
-  pageContext: { frontmatter },
-}) {
+export default function Template({ data: { mdx } }) {
+  const {
+    frontmatter,
+    body,
+    headings,
+    fields: { gitAuthorTime, lastUpdatedString, slug },
+  } = mdx
   return (
     <BlogPostLayout
       {...{
         frontmatter,
-        slug: path,
+        gitAuthorTime,
+        lastUpdatedString,
+        slug,
         fileType: ".mdx",
       }}
     >
-      <MDXProvider components={shortcodes}>{children}</MDXProvider>
+      <TableOfContents headings={headings} />
+      <MDXProvider components={shortcodes}>
+        <MDXRenderer>{body}</MDXRenderer>
+      </MDXProvider>
     </BlogPostLayout>
   )
 }
+
+export const pageQuery = graphql`
+  query($slug: String!) {
+    mdx(fields: { slug: { eq: $slug } }) {
+      body
+      frontmatter {
+        title
+      }
+      headings {
+        depth
+        value
+      }
+      fields {
+        slug
+        gitAuthorTime
+        lastUpdatedString: gitAuthorTime(formatString: "MMM Do YYYY")
+      }
+    }
+  }
+`


### PR DESCRIPTION
tldr: mdx pages (like the scheduling page) can now have "last updated" and table of contents andmost of the features as regular md files 

Problem: Do to a weird behavior of mdx plugin (https://github.com/gatsbyjs/gatsby/issues/24164) , the MDX pages could not get access to the same data as the md plugin.

Solution: Since now all guide info is in `src/guides` instead of `src/pages` , the MDX plugin can be used with the Gatsby createPages API, so it has access to the graphql page queries. This means we can add gitAuthorTime , and get all of the same features.