### PR TITLE
Related Guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Logs
+.vscode
 logs
 *.log
 npm-debug.log*

--- a/docs/how-to-write-a-good-guide.md
+++ b/docs/how-to-write-a-good-guide.md
@@ -1,11 +1,11 @@
 # Guide on Guides
 
-A guide is basically any article we write that intends to help out another Pitt CS student.
+A guide is any article we write that intends to help out another Pitt CS student.
 
 We consider a page that includes useful information to be a 'guide'. It can be short, like "How to become a TA", or it can be a series,
-like "Path through CS".
+like "Zero to Offer".
 
-Some guides are more refined, and deserve their own folder. Like, the `Zero to Offer` set.
+Some guides are more structured, and deserve their own folder. Like, the `Zero to Offer` set.
 
 We write them in Markdown.
 
@@ -15,20 +15,24 @@ To add a guide, open a PR, and create an appropiate markdown file in the `srcs/g
 
 Say you wish to create a new guide on how to study abroad.
 
-1. Add a new markdown file under `src/guides`, in the specific topic. Say, `study-abroad.md` under the `academics` folder.
-2. Make sure to add a frontmatter to your file. This is basically meta information at the top of your file.
+1. Look in the `src/guides` folder and see what topic it would fit under. Study Abroad seems like it would go under academics.
+1. Add a new markdown file under `src/guides/academics`, Call it `study-abroad.md`
+1. Make sure to add a frontmatter to your file. This is meta information at the top of your file.
 
 ```
 ---
 title: "Study Abroad"
+author: "If you want you can put your name!"
+search_tags: ["optional list of tags that are searchable"]
 ---
 
+## Do not use h1's, because the 'title' will automatically turn into an h1.
 Studying abroad as a CS major ...
 ```
 
-Make sure the very first line in your markdown file is the three dashes! If you have an extra newline it will not work.
+Make sure the _very first line_ in your markdown file is the three dashes! If you have an extra newline it will not work.
 
-Note the 'title' will be used as the title of the web page, displayed as a title, and it will be indexed so it can be searchable by the search bar.
+Note the 'title' will be used as the title of the web page, displayed as a title, and it will be indexed so it can be searchable by the search bar. You can add other search attributes in the search tags field.
 
 3. Submit a PR ([Follow these steps](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request))
 
@@ -39,8 +43,10 @@ After you a submit a PR and it is merged to the master branch, you are all set!
 Say you want to make 5 different guides about research.
 
 1. Make a new folder in the `src/guides/academics/` folder, called `research` (where academics is the appropiate category)
-2. Add an `index.md` in this folder to serve as on overview.
+2. Add an `index.md` in this folder to serve as on overview. (this will be reachable via /guides/academics/research/)
 3. Add more markdown files inside the folder!
+
+## Adding Related Guides
 
 If you would like to add a "Related Resources" section to the guide, add a
 "related" field to the frontmatter like so:
@@ -48,7 +54,7 @@ If you would like to add a "Related Resources" section to the guide, add a
 ```
 ---
 title: "Scheduling Classes"
-related: ["Stats Major", "./majors/stats", "Course Explorer", "/courses/"]
+related: ["Stats Major", "/academics/majors/stats", "Course Explorer", "/courses/"]
 ---
 ```
 

--- a/docs/how-to-write-a-good-guide.md
+++ b/docs/how-to-write-a-good-guide.md
@@ -42,6 +42,18 @@ Say you want to make 5 different guides about research.
 2. Add an `index.md` in this folder to serve as on overview.
 3. Add more markdown files inside the folder!
 
+If you would like to add a "Related Resources" section to the guide, add a
+"related" field to the frontmatter like so:
+
+```
+---
+title: "Scheduling Classes"
+related: ["Stats Major", "./majors/stats", "Course Explorer", "/courses/"]
+---
+```
+
+The related is a list, and starts with the title of the link, and next is the actual link.
+
 ## Guiding Principles
 
 (Pun Intended)

--- a/helpers/read-markdown.js
+++ b/helpers/read-markdown.js
@@ -35,7 +35,9 @@ const getData = async (sources) => {
 }
 
 const parseSlug = (pathSlug) => {
-  return pathSlug.replace(/\/index\.md$/g, "").replace(/\.mdx?$/g, "")
+  // remove any "md" or "mdx" extenstions, and if its an index page, remove
+  // the "index.md" part
+  return pathSlug.replace(/\/index\.mdx?$/g, "").replace(/\.mdx?$/g, "")
 }
 
 const parse = (data) => {

--- a/helpers/read-markdown.js
+++ b/helpers/read-markdown.js
@@ -3,7 +3,8 @@ const path = require("path")
 const { promisify } = require("util")
 const glob = promisify(require("glob"))
 const parseFrontMatter = require("gray-matter")
-const { siteGraphGenerator } = require("../src/utils/sitegraph-generator")
+const parseRelatedLinksFromFrontmatter = require("../src/utils/related-guides-parser")
+const parseMarkdownLinks = require("parse-markdown-links")
 
 const BASE_PATH = path.join(__dirname, "..", "src")
 
@@ -38,11 +39,19 @@ const parseSlug = (pathSlug) => {
 }
 
 const parse = (data) => {
-  return data.map((file) => ({
-    slug: parseSlug(file.pathSlug),
-    rawMarkdownBody: file.data,
-    title: parseFrontMatter(file.data).data.title,
-  }))
+  return data.map((file) => {
+    const frontmatter = parseFrontMatter(file.data).data
+    const relatedGuidesLinks = parseRelatedLinksFromFrontmatter(
+      frontmatter.related
+    ).map((l) => l.link)
+    const markdownLinks = parseMarkdownLinks(file.data) || []
+    return {
+      slug: parseSlug(file.pathSlug),
+      rawMarkdownBody: file.data,
+      title: frontmatter.title,
+      links: relatedGuidesLinks.concat(markdownLinks),
+    }
+  })
 }
 
 module.exports = async function () {

--- a/src/components/courses/course-graph.js
+++ b/src/components/courses/course-graph.js
@@ -60,7 +60,7 @@ export default ({ reqs, showPreview = false }) => {
 
   return (
     <div className="lg:flex">
-      <div class="w-full overflow-x-auto">
+      <div className="w-full overflow-x-auto">
         <DagreGraph
           nodes={nodes}
           links={links}

--- a/src/components/templates/blog-post-layout.js
+++ b/src/components/templates/blog-post-layout.js
@@ -3,6 +3,7 @@ import Layout from "../layout"
 import SEO from "../seo"
 import Breadcrumb from "../breadcrumb"
 import FeedbackWidget from "../feedback"
+import relatedGuidesParser from "../../utils/related-guides-parser"
 
 export default function BlogPostLayout({
   frontmatter,
@@ -39,6 +40,7 @@ export default function BlogPostLayout({
           </div>
           <FreshnessDisclaimer lastUpdated={gitAuthorTime} />
           {children}
+          <RelatedGuides related={frontmatter.related} />
           <div
             className={
               "my-8 text-center sm:w-full md:w-auto " +
@@ -62,6 +64,29 @@ export default function BlogPostLayout({
         </div>
       </div>
     </Layout>
+  )
+}
+
+const RelatedGuides = ({ related }) => {
+  console.log(related)
+  const links = relatedGuidesParser(related)
+  console.log(links)
+
+  if (!links || links.length === 0) return null
+
+  return (
+    <div className="text-sm border-t border-b py-4">
+      <h4 className="mb-1">Related Resources</h4>
+      <ul className="mb-0">
+        {links.map(({ link, title }, i) =>
+          !link || !title ? null : (
+            <li key={i}>
+              <a href={link}>{title}</a>
+            </li>
+          )
+        )}
+      </ul>
+    </div>
   )
 }
 

--- a/src/components/templates/blog-post-layout.js
+++ b/src/components/templates/blog-post-layout.js
@@ -2,6 +2,7 @@ import React from "react"
 import Layout from "../layout"
 import SEO from "../seo"
 import Breadcrumb from "../breadcrumb"
+import { Link } from "gatsby"
 import FeedbackWidget from "../feedback"
 import relatedGuidesParser from "../../utils/related-guides-parser"
 
@@ -68,9 +69,7 @@ export default function BlogPostLayout({
 }
 
 const RelatedGuides = ({ related }) => {
-  console.log(related)
   const links = relatedGuidesParser(related)
-  console.log(links)
 
   if (!links || links.length === 0) return null
 
@@ -81,7 +80,7 @@ const RelatedGuides = ({ related }) => {
         {links.map(({ link, title }, i) =>
           !link || !title ? null : (
             <li key={i}>
-              <a href={link}>{title}</a>
+              <Link to={link}>{title}</Link>
             </li>
           )
         )}

--- a/src/components/templates/guide-template.js
+++ b/src/components/templates/guide-template.js
@@ -45,6 +45,7 @@ export const pageQuery = graphql`
         title
         subtitle
         author
+        related
       }
       headings {
         depth

--- a/src/guides/academics/bsms.md
+++ b/src/guides/academics/bsms.md
@@ -1,5 +1,6 @@
 ---
 title: "Pitt BS + MS Program"
+related: ["Research", "./research", "Scheduling", "./scheduling"]
 ---
 
 ## BS + MS Program

--- a/src/guides/academics/bsms.md
+++ b/src/guides/academics/bsms.md
@@ -1,6 +1,7 @@
 ---
 title: "Pitt BS + MS Program"
-related: ["Research", "./research", "Scheduling", "./scheduling"]
+related:
+  ["Research", "/academics/research", "Scheduling", "/academics/scheduling"]
 ---
 
 ## BS + MS Program

--- a/src/guides/academics/high-school.md
+++ b/src/guides/academics/high-school.md
@@ -1,6 +1,7 @@
 ---
 title: "High Schooler"
 search_tags: ["freshmen", "incoming", "is pitt right for me"]
+related: ["Other Pitt Resources", "/misc/external-resources/"]
 ---
 
 Are you are a high schooler? Considering college or CS? This page is for you.

--- a/src/guides/academics/majors/index.md
+++ b/src/guides/academics/majors/index.md
@@ -2,4 +2,4 @@
 title: "Double Major?"
 ---
 
-[Stat](./stats)
+[Stat](/academics/majors/stats)

--- a/src/guides/academics/minors/index.md
+++ b/src/guides/academics/minors/index.md
@@ -4,6 +4,6 @@ title: "CS + Another Minor"
 
 Interested in other minors?
 
-[Stat](./stats/)
+[Stat](/academics/minors/stats/)
 
 TODO - reorganize these

--- a/src/guides/academics/scheduling.mdx
+++ b/src/guides/academics/scheduling.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Scheduling Classes"
+related: ["Stats Major", "./majors/stats", "Course Explorer", "/courses/"]
 ---
 
 This is a definitive guide with a lot of FAQs. If you have a question, check the FAQ or

--- a/src/guides/academics/scheduling.mdx
+++ b/src/guides/academics/scheduling.mdx
@@ -1,6 +1,14 @@
 ---
 title: "Scheduling Classes"
-related: ["Stats Major", "./majors/stats", "Course Explorer", "/courses/"]
+related:
+  [
+    "Course Explorer",
+    "/courses/",
+    "Double Majoring",
+    "/academics/majors/",
+    "Minors",
+    "/academics/minors/",
+  ]
 ---
 
 This is a definitive guide with a lot of FAQs. If you have a question, check the FAQ or

--- a/src/guides/academics/study-abroad.md
+++ b/src/guides/academics/study-abroad.md
@@ -1,7 +1,8 @@
 ---
 title: "Study Abroad"
 search_tags:
-  - "rohit ganguly"
+  - "korea"
+related: ["Scheduling", "/academics/scheduling"]
 ---
 
 Studying abroad is one of the most exciting and unique things you can do during your time at Pitt. In this guide we will explain the basics of how to study abroad as a Pitt CS student. You can learn more about specific programs at [abroad.pitt.edu/](https://abroad.pitt.edu "Study Abroad at Pitt").

--- a/src/utils/related-guides-parser.js
+++ b/src/utils/related-guides-parser.js
@@ -7,7 +7,7 @@
 // so we parse them into [{link: "/majors/stats/", title: "Stats"}, ...]
 // and do error handling
 // ---
-export default function (relatedLinks) {
+module.exports = function (relatedLinks) {
   const links = []
 
   if (!relatedLinks || !relatedLinks.length || relatedLinks.length % 2 !== 0) {

--- a/src/utils/related-guides-parser.js
+++ b/src/utils/related-guides-parser.js
@@ -1,0 +1,22 @@
+// Gatsby cant handle YAML with nested objects, so instead
+// related links look like
+// ---
+// title: "Scheduling Classes"
+// related:
+//   ["Stats Major", "./majors/stats", "asd", "Course Explorer", "/courses/"]
+// so we parse them into [{link: "/majors/stats/", title: "Stats"}, ...]
+// and do error handling
+// ---
+export default function (relatedLinks) {
+  const links = []
+
+  if (!relatedLinks || !relatedLinks.length || relatedLinks.length % 2 !== 0) {
+    return links
+  }
+
+  for (let i = 0; i < relatedLinks.length; i += 2) {
+    links.push({ title: relatedLinks[i], link: relatedLinks[i + 1] })
+  }
+
+  return links
+}

--- a/src/utils/sitegraph-generator.js
+++ b/src/utils/sitegraph-generator.js
@@ -20,17 +20,19 @@ const convertLinkToFullPath = (link, node) => {
     if (link.substring(0, 2) === "./") {
       // Support relative links, like "./bsms" would point to "/academics/bsms"
       // if the link was in academics folder index page.
-      // however, if the current page is not an indexPage, then we replace
-      // the current page
-      const linkWithoutDot = link.substring(2)
-      if (node.fields.isIndexPage) {
-        link = basePath + linkWithoutDot
-      } else {
-        link = basePath.replace(/\/\w*\/$/g, "/" + linkWithoutDot)
+      // however, if the current page is not an indexPage, then there is a really
+      // weird bug that stops it from working sometimes. no clue what is happening.
+      // It is probably better to use relative linking.
+      link = basePath + link.substring(2)
+      if (basePath.split("/").length !== 3) {
+        return {
+          error:
+            "Only use relative linking on certain pages. Read PR #162 for more details",
+        }
       }
     } else {
       return {
-        eror:
+        error:
           "We only support one level of relative linking (./bsms) not (../zero-to-offer). This makes it too difficult to test.",
       }
     }
@@ -115,7 +117,7 @@ function siteGraphGenerator(sites, pages) {
           errors.push({
             file: node.slug,
             brokenLink: link,
-            msg: "Could not parse",
+            msg: parsedLink.error,
           })
         } else {
           if (!isExternalLink(parsedLink) && !siteMap[parsedLink]) {

--- a/src/utils/sitegraph-generator.js
+++ b/src/utils/sitegraph-generator.js
@@ -1,5 +1,3 @@
-const parse = require("parse-markdown-links")
-
 // this code is confusing because its like an interview question,
 // given a flat list of urls, construct a tree diagram, and ensure no
 // broken links contained in the urls
@@ -19,6 +17,7 @@ const parseLink = (link, basePath) => {
     // Support relative links, like "./bsms" would point to "/academics/bsms"
     // if the link was in academics folder
     link = basePath + link.substring(2)
+    console.log(link)
   }
   // links can be malformed
   if (link[0] !== "/" && !isExternalLink(link)) {
@@ -53,7 +52,7 @@ function siteGraphGenerator(sites, pages) {
     return {
       id: cleanSiteLink(node.slug),
       slug: node.slug,
-      links: node.rawMarkdownBody ? parse(node.rawMarkdownBody) : undefined,
+      links: node.links, // node.links is defined during tests
       title: node.title,
     }
   })

--- a/tests/links.test.js
+++ b/tests/links.test.js
@@ -7,6 +7,7 @@ test("No broken links or missing index files", async () => {
   const sites = data
     .map((node) => node.slug)
     .concat(["/courses/", "/about/", "/guides/", "/sitemap/"])
+
   const { errors } = siteGraphGenerator(sites, data)
   if (errors.length > 0) {
     console.log("Broken Links:")


### PR DESCRIPTION
If you would like to add a "Related Resources" section to the guide, add a
"related" field to the frontmatter like so:

```
---
title: "Scheduling Classes"
related: ["Stats Major", "/academics/majors/stats", "Course Explorer", "/courses/"]
---
```

![image](https://user-images.githubusercontent.com/13937711/86390513-30d25c00-bc66-11ea-9d91-769f0ee2c369.png)


The related is a list, and starts with the title of the link, and next is the actual link.


## Weird Bug
For some weird chrome bug, relative links do not work. If you have a relative link on the /academics/majors/index.md file that points to "./stats" , it works sometimes. It will work if you navigate to /academics/majors , and then click the stats link. But, if you go from /academics/ to /academics/majors/ and then click a link, it does not work. To make things easier, just gonna say dont use relative linking.

close #104 