### PR TITLE
[WIP] Revamped Scheduling Guide

### DIFF
--- a/src/guides/academics/scheduling.mdx
+++ b/src/guides/academics/scheduling.mdx
@@ -11,12 +11,12 @@ related:
   ]
 ---
 
-To start, let's look at the core CS classes required for the major. It
+Let's look at the core CS classes required for the major. It
 might look intimadating at first, but it just shows the requirements
 of classes. For example, to take CS 1501, you must take CS 441 and CS 445.
 
 The dashed lines mean those classes are "coreqs". For example, you can take CS 449 if you are taking CS 447 in the semester. But, you cannot take
-CS 447 after 449.
+CS 449 before CS 447.
 
 <CourseGraph
   reqs={[
@@ -40,11 +40,11 @@ The core courses can be broken up into different tracks.
 
 **Core Programming Intensive**
 
-These classes teach the most fundamental CS concepts. Pay attention!
+These classes teach the most fundamental CS concepts. **Bolded classes** are considered very demanding. 
 
 - CMP 401
 - CS 445
-- CS 1501
+- **CS 1501**
 
 **Mathy**
 
@@ -58,78 +58,159 @@ These are more theory based classes that involve proofs and math.
 Do you actually know how a computer works? These classes will teach you!
 
 - CS 447
-- CS 449
-- CS 1550
+- **CS 449**
+- **CS 1550**
 
-## Full Requirements
+## Related Links
 
-View the full requirements: http://sci.pitt.edu/wp-content/uploads/2019/09/computer-science.pdf
+The full requirements: https://www.sci.pitt.edu/academics/undergraduate-majors/computer-science
 
-This information is here - http://sci.pitt.edu/academics/ugrad/cs/
+More information here: http://sci.pitt.edu/academics/ugrad/cs/
 
-The CS major is about 40 credits plus a capstone course. Read about the CS capstone [here](/academics/registration/capstone/)
+CS Capstone Guide: https://pittcs.wiki/academics/registration/capstone/
 
 ## Potential Schedules
 
-When starting out, we recommend taking CS 441 and CMP 401 together. Or, if you have never programmed before and unsure if you
-will like it, you can start off with CS 007.
-
-Note CS 1501 and CS 1550 are pretty demanding courses.
+We recommend taking CS445 and CS1501 as soon as possible. These courses form the foundation of your CS education and will unlock a lot of upper electives. They also are an absolute necessity for technical interviews. 
 
 Making a Good CS Plan
 
-1. Take 401 and 445 early on
+1. Take 401, 445, and 1501 early on
 2. Decide which semester you will take 1501.
-3. Throw away the plan (Especially in college, things will change!)
+3. Throw away the plan (in college, things change!)
 
 Below are some potential schedules. Your schedule will look different depending on your other classes!
 
-Whenever you schedule a class make sure to play close attention to the professor. It's better to optimize your schedule
-to have better professors! Most profressors that teach the core classes are quite good. Check the respective pages for each
-course on this wiki and use Rate My Professor.
+Whenever you schedule a class make sure to **play close attention to the professor**. It's better to optimize your schedule
+to have better professors good. Check the respective pages for each course on the wiki and use Rate My Professor.
 
-This **are just example schedules**. Your own schedule will likely look different. You need to consider what other majors/minors you will have,
-and what other electives (both CS and Non CS) and gen eds you need to take.
+**Note:** These **are just example schedules**. Everyone's situation is different and yours will likely look different.
 
-**A**
+**A - Common**
 
 | Semester 1 | Semester 2 | Semester 3 | Semester 4 | Semester 5 |
 | ---------- | ---------- | ---------- | ---------- | ---------- |
-| 401        | 441        | 447        | 1501       | 1550       |
-|            | 445        | 449        |            | 1502       |
+| 401        | 441        | 447        | 449        | 1550       |
+|            | 445        | 1501       | 1502       |            |
 
-**B**
+**B - Common**
 
-| Semester 1 | Semester 2 | Semester 3 | Semester 4 |
-| ---------- | ---------- | ---------- | ---------- |
-| 401        | 447        | 1501       | 1550       |
-| 441        | 445        | 449        |            |
-|            |            | 1502       |            |
+| Semester 1 | Semester 2 | Semester 3 | Semester 4  | Semester 5    |
+| ---------- | ---------- | ---------- | ----------- | ------------- |
+| 401        | 447        | 1501       | 449         | 1550          |
+| 441        | 445        | 1502       | CS Elective | CS Elective   |
 
-**C**
+**C - Common**
+
+| Semester 1 | Semester 2 | Semester 3 | Semester 4  |
+| ---------- | ---------- | ---------- | ----------- |
+| 401        | 447        | 449        | 1502        |
+| 441        | 445        | 1501       | 1550        |
+
+**D - Common**
+
+| Semester 1  | Semester 2 | Semester 3 | Semester 4 | Semester 5   |
+| ----------- | ---------- | ---------- | ---------- | ------------ |
+| 007/ 010    | 401        | 445        | 1501       | 449          |
+|             | 441        | 447        | 1502       | CS Elective  |
+
+**E - Slowish Start**
+
+| Semester 1  | Semester 2 | Semester 3 | Semester 4 | Semester 5  |
+| ----------- | ---------- | ---------- | ---------- | ----------- |
+| 007/ 010    | 401        | 445        | 1501       | 449         |
+|             |            | 441        | 447        | 1502        |
+
+**F - Slowish Start (Tougher)**
+
+| Semester 1  | Semester 2 | Semester 3 | Semester 4 | Semester 5    |
+| ----------- | ---------- | ---------- | ---------- | ------------- |
+| 007/ 010    | 401        | 445        | 1501       | 449           |
+|             |            | 441        | 1502       | CS Elective   |
+|            |            | 447        |            |               |
+
+**G - Slowish Start (Toughest)**
+
+| Semester 1  | Semester 2 | Semester 3 | Semester 4 | Semester 5    |
+| ----------- | ---------- | ---------- | ---------- | ------------- |
+| 007/ 010    | 401        | 445        | 1501       | 1550          |
+|             |            | 441        | 1502       | CS Elective   |
+|             |            | 447        | 449        |               |
+
+**H - AP Credit required**
 
 | Semester 1 | Semester 2 | Semester 3 | Semester 4  |
 | ---------- | ---------- | ---------- | ----------- |
 | 445        | 447        | 1501       | 1550        |
 | 441        | 449        | 1502       | CS Elective |
 
+**G - Tryhard**
+
+| Semester 1 | Semester 2 | Semester 3 | Semester 4      |
+| ---------- | ---------- | ---------- | --------------- |
+| 401        | 447        | 1501       | 1550            |
+| 441        | 445        | 449        | CS Elective(s)  |
+|            |            | 1502       |                 |
+
+
 ## What should I take with these CS classes?
 
-It depends on the rigor of the CS course, and the professor. Notably, if we are talking about CS 1501, I would not have a heavy course load. I would recommend taking a class like Calculus II when you are taking lower-level CS courses such as CS449 and below, or upper-level CS electives.
+It depends on the rigor of the CS course, and the professor. Notably, if we are talking about CS 1501, we would not want a heavy course load. We also recommend taking a class like Calculus II when you are taking lower-level CS courses such as CS449 and below, or upper-level CS electives.
 
-I would likely take some light gen-eds with CS 1501, or any of the upper level CS courses (CS 1502, CS 1550).
+We would likely take some light gen-eds with CS 1501 or CS 1550. As noted, they are demanding and you wouldn't want other tough classes from interfering with them.
 
 ## CS Electives
 
-You discover your interests as you take some electives. A good way to determine a path to follow would be the following link: https://cs.pitt.edu/degrees/bachelors/requirements/concentrations/
+You discover your interests in CS as you take some electives. You’re not limited to take classes in a certain domain, but try to take classes that you'll enjoy. Electives are meant to cover topics you want to explore, not classes you suffer in.
 
-Of course, you’re not limited to take classes in a certain path, but it’s important to take classes about subjects in Computer Science that you may enjoy. Electives are meant to be classes you want to enjoy, not classes you suffer in.
-
-For example, if you didn’t enjoy CS 447 and CS 449, and don’t like to deal with CPUs, you probably don’t want to take Computer Architecture
+Didn’t enjoy CS 447, 449, or 1550? You probably don’t want to take Computer Architecture or other low level courses.
 
 On the other hand, if you enjoy certain parts of CS 1501, such as the introduction to cryptography section, CS 1653 would probably be a good elective to take.
 
 Check out the [course explorer](/courses) to look at the different electives that are offered. Pick the ones that pique your interest.
+
+## CSC's highly subjective CS Electives Difficulty Ranking
+These rankings are incredibly subjective and difficulty varies more by professor rather than course. 
+
+| **S Tier: Rough**                |
+| -------------------------------- |
+| CS 1510 - Algorithm Design       |
+| CS 1511 - Theory of Computation  |
+
+| **A Tier: A Tough Challenge**                       |
+| --------------------------------------------------- |
+| CS 1541 - Intro to Computer Architecture            |
+| CS 1622 - Intro to Compiler Design                  |
+| CS 1651 - Advanced Systems Software                 |
+| CS 1652 - Data Communication and Computer Networks  |
+| CS 1675 - Intro to Machine Learning                 |
+
+| **B Tier: Quite a Challenge**                         |
+| ----------------------------------------------------- |
+| CS 1566 - Intro to Computer Graphics                  |
+| CS 1571 - Intro to Artificial Intelligence            |
+| CS 1645 - Intro to High Performance Computing Systems |
+| CS 1653 - Applied Crypto and Network Security         |
+| CS 1657 - Privacy in Electronic Society               |
+
+| **C Tier: A Challenge**                                         |
+| --------------------------------------------------------------- |
+| CS 1555 - Database Management Systems                           |
+| CS 1567 - Robotic System Design                                 |
+| CS 1666 - Principles of Computer Game Design and Implementation |
+| CS 1671 - Intro to Human Computer Interaction                   |
+| CS 1674 - Intro to Computer Vision                              |
+| CS 1678 - Intro to Deep Learning                                |
+| CS 1699 - Special Topics (these vary in difficulty, but because they're experiemental they're graded leniently) |
+
+| **D Tier: Not Bad**                                 |
+| --------------------------------------------------- |
+| CS 1520 - Programming Language for Web Applications |
+| CS 1530 - Software Engineering                      |
+| CS 1621 - Structure Programming Languages           |
+| CS 1632 - Software Quality Assurance                |
+| CS 1656 - Intro to Data Science                     |
+| CS 1660 - Intro to Cloud Computing                  |
 
 ## FAQ
 
@@ -141,6 +222,8 @@ If you have never programmed before, take CS 007. If you have experience program
 
 If you have enough credits, you can graduate early! It is a great way to save some tuition money. But, there are also some more classes that can help you as a CS major.
 
-It really depends on what your interests are. For example, if you are interested in Data Science, I would recommend taking some Statistics classes. In particular, STAT 1261, and STAT 1201 would be excellent options.
+It really depends on what your interests are. For example, if you are interested in Data Science, we would recommend taking some Statistics classes. In particular, STAT 1261, and STAT 1201 would be excellent options.
 
-If you are interested in Cryptography, I would recommend taking some Math classes. In particular, Introduction to Mathematical Cryptography, Elementary Number Theory, Combinatorial Mathematics, would be great options. Note that all these classes require MATH 413.
+If you are interested in Cryptography, we would recommend taking some Math classes. In particular, Introduction to Mathematical Cryptography, Elementary Number Theory, Combinatorial Mathematics, would be great options. Note that all these classes require MATH 413.
+
+If you're interested in writing/improving your communication and expression skills, the Creative Writing minor is a great choice!

--- a/src/guides/academics/scheduling.mdx
+++ b/src/guides/academics/scheduling.mdx
@@ -161,57 +161,53 @@ We would likely take some light gen-eds with CS 1501 or CS 1550. As noted, they 
 
 ## CS Electives
 
-You discover your interests in CS as you take some electives. You’re not limited to take classes in a certain domain, but try to take classes that you'll enjoy. Electives are meant to cover topics you want to explore, not classes you suffer in.
-
-Didn’t enjoy CS 447, 449, or 1550? You probably don’t want to take Computer Architecture or other low level courses.
-
-On the other hand, if you enjoy certain parts of CS 1501, such as the introduction to cryptography section, CS 1653 would probably be a good elective to take.
+You discover your interests in CS as you take some electives. You’re not limited to take classes in a certain domain, but try to take classes that you'll enjoy. Electives are meant to cover topics you want to explore, not classes you suffer in. For example, if you didn’t enjoy CS 447, 449, or 1550 you probably don’t want to take Computer Architecture or other low level courses. On the other hand, if you enjoy certain parts of CS 1501, such as the introduction to cryptography section, CS 1653 would probably be a good elective to take.
 
 Check out the [course explorer](/courses) to look at the different electives that are offered. Pick the ones that pique your interest.
 
 ## CSC's highly subjective CS Electives Difficulty Ranking
 These rankings are incredibly subjective and difficulty varies more by professor rather than course. 
 
-| **S Tier: Rough**                |
-| -------------------------------- |
-| CS 1510 - Algorithm Design       |
-| CS 1511 - Theory of Computation  |
+| **S Tier: Rough** | 
+| -------------------------------- | 
+| [CS 1510 - Algorithm Design](/courses/CS1510) | 
+| [CS 1511 - Theory of Computation](/courses/CS1511) | 
 
-| **A Tier: A Tough Challenge**                       |
-| --------------------------------------------------- |
-| CS 1541 - Intro to Computer Architecture            |
-| CS 1622 - Intro to Compiler Design                  |
-| CS 1651 - Advanced Systems Software                 |
-| CS 1652 - Data Communication and Computer Networks  |
-| CS 1675 - Intro to Machine Learning                 |
+| **A Tier: A Tough Challenge** | 
+| --------------------------------------------------- | 
+| [CS 1541 - Intro to Computer Architecture](/courses/CS1541) | 
+| [CS 1622 - Intro to Compiler Design](/courses/CS1622) |
+| [CS 1651 - Advanced Systems Software](/courses/CS1651) | 
+| [CS 1652 - Data Communication and Computer Networks](/courses/CS1652) | 
+| [CS 1675 - Intro to Machine Learning](/courses/CS1675) | 
 
-| **B Tier: Quite a Challenge**                         |
-| ----------------------------------------------------- |
-| CS 1566 - Intro to Computer Graphics                  |
-| CS 1571 - Intro to Artificial Intelligence            |
-| CS 1645 - Intro to High Performance Computing Systems |
-| CS 1653 - Applied Crypto and Network Security         |
-| CS 1657 - Privacy in Electronic Society               |
+| **B Tier: Quite a Challenge** | 
+| ----------------------------------------------------- | 
+| [CS 1566 - Intro to Computer Graphics](/courses/CS1566) | 
+| [CS 1571 - Intro to Artificial Intelligence](/courses/CS1571) | 
+| [CS 1645 - Intro to High Performance Computing Systems](/courses/CS1645) | 
+| [CS 1653 - Applied Crypto and Network Security](/courses/CS1653) | 
+| [CS 1657 - Privacy in Electronic Society](/courses/CS1657) | 
 
-| **C Tier: A Challenge**                                         |
-| --------------------------------------------------------------- |
-| CS 1555 - Database Management Systems                           |
-| CS 1567 - Robotic System Design                                 |
-| CS 1637 - Intro to Human Computer Interaction                   |
-| CS 1666 - Principles of Computer Game Design and Implementation |
-| CS 1671 - Human Language Technologies                           |
-| CS 1674 - Intro to Computer Vision                              |
-| CS 1678 - Intro to Deep Learning                                |
-| CS 1699 - Special Topics (these vary in difficulty, but because they're experiemental they're graded leniently) |
+| **C Tier: A Challenge** | 
+| --------------------------------------------------------------- | 
+| [CS 1555 - Database Management Systems](/courses/CS1555) | 
+| [CS 1567 - Robotic System Design](/courses/CS1567) | 
+| [CS 1637 - Intro to Human Computer Interaction](/courses/CS1637) | 
+| [CS 1666 - Principles of Computer Game Design and Implementation](/courses/CS1666) | 
+| [CS 1671 - Human Language Technologies](/courses/CS1671) | 
+| [CS 1674 - Intro to Computer Vision](/courses/CS1674) | 
+| [CS 1678 - Intro to Deep Learning](/courses/CS1678) | 
+| [CS 1699 - Special Topics (these vary in difficulty, but because they're experimental they're graded leniently)](/courses/CS1699) | 
 
-| **D Tier: Not Bad**                                 |
-| --------------------------------------------------- |
-| CS 1520 - Programming Language for Web Applications |
-| CS 1530 - Software Engineering                      |
-| CS 1621 - Structure Programming Languages           |
-| CS 1632 - Software Quality Assurance                |
-| CS 1656 - Intro to Data Science                     |
-| CS 1660 - Intro to Cloud Computing                  |
+| **D Tier: Not Bad** | 
+| --------------------------------------------------- | 
+| [CS 1520 - Programming Language for Web Applications](/courses/CS1520) | 
+| [CS 1530 - Software Engineering](/courses/CS1530) | 
+| [CS 1621 - Structure Programming Languages](/courses/CS1621) | 
+| [CS 1632 - Software Quality Assurance](/courses/CS1632) | 
+| [CS 1656 - Intro to Data Science](/courses/CS1656) | 
+| [CS 1660 - Intro to Cloud Computing](/courses/CS1660) |
 
 ## FAQ
 

--- a/src/guides/academics/scheduling.mdx
+++ b/src/guides/academics/scheduling.mdx
@@ -197,7 +197,7 @@ These rankings are incredibly subjective and difficulty varies more by professor
 | [CS 1666 - Principles of Computer Game Design and Implementation](/courses/CS1666) | 
 | [CS 1671 - Human Language Technologies](/courses/CS1671) | 
 | [CS 1674 - Intro to Computer Vision](/courses/CS1674) | 
-| [CS 1678 - Intro to Deep Learning](/courses/CS1678) | 
+| CS 1678 - Intro to Deep Learning | 
 | [CS 1699 - Special Topics (these vary in difficulty, but because they're experimental they're graded leniently)](/courses/CS1699) | 
 
 | **D Tier: Not Bad** | 

--- a/src/guides/academics/scheduling.mdx
+++ b/src/guides/academics/scheduling.mdx
@@ -86,42 +86,42 @@ to have better professors good. Check the respective pages for each course on th
 
 **Note:** These **are just example schedules**. Everyone's situation is different and yours will likely look different.
 
-**A - Common**
+### A - Common
 
 | Semester 1 | Semester 2 | Semester 3 | Semester 4 | Semester 5 |
 | ---------- | ---------- | ---------- | ---------- | ---------- |
 | 401        | 441        | 447        | 449        | 1550       |
 |            | 445        | 1501       | 1502       |            |
 
-**B - Common**
+### B - Common
 
 | Semester 1 | Semester 2 | Semester 3 | Semester 4  | Semester 5    |
 | ---------- | ---------- | ---------- | ----------- | ------------- |
 | 401        | 447        | 1501       | 449         | 1550          |
 | 441        | 445        | 1502       | CS Elective | CS Elective   |
 
-**C - Common**
+### C - Common
 
 | Semester 1 | Semester 2 | Semester 3 | Semester 4  |
 | ---------- | ---------- | ---------- | ----------- |
 | 401        | 447        | 449        | 1502        |
 | 441        | 445        | 1501       | 1550        |
 
-**D - Common**
+### D - Common
 
 | Semester 1  | Semester 2 | Semester 3 | Semester 4 | Semester 5   |
 | ----------- | ---------- | ---------- | ---------- | ------------ |
 | 007/ 010    | 401        | 445        | 1501       | 449          |
 |             | 441        | 447        | 1502       | CS Elective  |
 
-**E - Slowish Start**
+### E - Slowish Start
 
 | Semester 1  | Semester 2 | Semester 3 | Semester 4 | Semester 5  |
 | ----------- | ---------- | ---------- | ---------- | ----------- |
 | 007/ 010    | 401        | 445        | 1501       | 449         |
 |             |            | 441        | 447        | 1502        |
 
-**F - Slowish Start (Tougher)**
+### F - Slowish Start (Tougher)
 
 | Semester 1  | Semester 2 | Semester 3 | Semester 4 | Semester 5    |
 | ----------- | ---------- | ---------- | ---------- | ------------- |
@@ -129,7 +129,7 @@ to have better professors good. Check the respective pages for each course on th
 |             |            | 441        | 1502       | CS Elective   |
 |            |            | 447        |            |               |
 
-**G - Slowish Start (Toughest)**
+### G - Slowish Start (Toughest)
 
 | Semester 1  | Semester 2 | Semester 3 | Semester 4 | Semester 5    |
 | ----------- | ---------- | ---------- | ---------- | ------------- |
@@ -137,14 +137,14 @@ to have better professors good. Check the respective pages for each course on th
 |             |            | 441        | 1502       | CS Elective   |
 |             |            | 447        | 449        |               |
 
-**H - AP Credit required**
+### H - AP Credit required
 
 | Semester 1 | Semester 2 | Semester 3 | Semester 4  |
 | ---------- | ---------- | ---------- | ----------- |
 | 445        | 447        | 1501       | 1550        |
 | 441        | 449        | 1502       | CS Elective |
 
-**G - Tryhard**
+### G - Tryhard
 
 | Semester 1 | Semester 2 | Semester 3 | Semester 4      |
 | ---------- | ---------- | ---------- | --------------- |

--- a/src/guides/academics/scheduling.mdx
+++ b/src/guides/academics/scheduling.mdx
@@ -197,8 +197,9 @@ These rankings are incredibly subjective and difficulty varies more by professor
 | --------------------------------------------------------------- |
 | CS 1555 - Database Management Systems                           |
 | CS 1567 - Robotic System Design                                 |
+| CS 1637 - Intro to Human Computer Interaction                   |
 | CS 1666 - Principles of Computer Game Design and Implementation |
-| CS 1671 - Intro to Human Computer Interaction                   |
+| CS 1671 - Human Language Technologies                           |
 | CS 1674 - Intro to Computer Vision                              |
 | CS 1678 - Intro to Deep Learning                                |
 | CS 1699 - Special Topics (these vary in difficulty, but because they're experiemental they're graded leniently) |

--- a/src/guides/academics/scheduling.mdx
+++ b/src/guides/academics/scheduling.mdx
@@ -187,7 +187,7 @@ These rankings are incredibly subjective and difficulty varies more by professor
 | [CS 1571 - Intro to Artificial Intelligence](/courses/CS1571) | 
 | [CS 1645 - Intro to High Performance Computing Systems](/courses/CS1645) | 
 | [CS 1653 - Applied Crypto and Network Security](/courses/CS1653) | 
-| [CS 1657 - Privacy in Electronic Society](/courses/CS1657) | 
+| CS 1657 - Privacy in Electronic Society | 
 
 | **C Tier: A Challenge** | 
 | --------------------------------------------------------------- | 

--- a/src/guides/academics/scheduling.mdx
+++ b/src/guides/academics/scheduling.mdx
@@ -155,7 +155,7 @@ to have better professors good. Check the respective pages for each course on th
 
 ## What should I take with these CS classes?
 
-It depends on the rigor of the CS course, and the professor. Notably, if we are talking about CS 1501, we would not want a heavy course load. We also recommend taking a class like Calculus II when you are taking lower-level CS courses such as CS449 and below, or upper-level CS electives.
+It depends on the rigor of the CS course, and the professor. Notably, if we are talking about CS 1501, we would not want a heavy course load. We recommend not taking Calculus II with CS1501/CS1550 as they are very demanding. Instead, take Calc with a lower level required course like 401 or 449 or take it with your upper electives!
 
 We would likely take some light gen-eds with CS 1501 or CS 1550. As noted, they are demanding and you wouldn't want other tough classes from interfering with them.
 


### PR DESCRIPTION
Scheduling advice is one of the biggest reasons why people join CSC and the Wiki's current scheduling guide was looking a little weak sauce. Decided to add some more information to preemptively answer questions. Open to any feedback on the changes, would prefer it be more than just me giving the schedule/ course advice.

### [More schedules](https://github.com/PittCSWiki/pittcswiki/blob/e8a5032a5349705e713966af8446a0f790441da6/src/guides/academics/scheduling.mdx#potential-schedules)
We currently have three schedules, one of which recommends taking 449, 1501, and 1502 in the same semester and another which requires AP credit. I added more schedules that felt more realistic based off conversations with underclassmen over the last year. I also added labels for each schedule so people have more context about the difficulty level for each one. 

### [Elective Difficulty Ranking](https://github.com/PittCSWiki/pittcswiki/blob/e8a5032a5349705e713966af8446a0f790441da6/src/guides/academics/scheduling.mdx#cscs-highly-subjective-cs-electives-difficulty-ranking) 
Based off my own opinion, I categorized the upper cs electives by difficulty. It is highly subjective and would appreciate any input. Also we should make each course a link to their course page (lotsa work lol).  Might've forgotten a class or two.

### TODO: Elective Material Grouping
I'm interested in grouping the classes by topic (ex: Software Engineering, Low Level, AI/ML, etc.) so that way people can pick and choose from topics that interest them.

### Various Refactoring
I reworded and rewrote a bunch. Most significant is probably the [related links](https://github.com/PittCSWiki/pittcswiki/blob/e8a5032a5349705e713966af8446a0f790441da6/src/guides/academics/scheduling.mdx#related-links) section.  Changes are best seen in the [diff view](https://github.com/PittCSWiki/pittcswiki/pull/286/files)
