### PR TITLE
Fix typo in scheduling

### DIFF
--- a/src/guides/academics/scheduling.mdx
+++ b/src/guides/academics/scheduling.mdx
@@ -213,7 +213,7 @@ These rankings are incredibly subjective and difficulty varies more by professor
 
 ### CS 007 or CS 401?
 
-If you have never programmed before, take CS 007. If you have experience programmed, take 401. If you have AP Computer Science credit, definitely skip 401.
+If you have never programmed before, take CS 007. If you have experience programming, take 401. If you have AP Computer Science credit, definitely skip 401.
 
 ### Should I Graduate Early?
 


### PR DESCRIPTION
Changed "if you have experience programmed" to "if you have experience programming". Testing PR before re-writing taking cs0007 vs. cs0401.